### PR TITLE
Fixed the plugin.xml after the namespace had changed

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,7 @@
 
     <engines>
       <engine name="cordova" version=">=3.0.0" />
-    </engines>    
+    </engines>
 
     <js-module src="www/sms.js" name="Sms">
         <clobbers target="window.sms" />
@@ -30,7 +30,7 @@
             <uses-feature android:name="android.hardware.telephony" android:required="false" />
         </config-file>
 
-        <source-file src="src/android/Sms.java" target-dir="src/org/apache/cordova/plugin/sms" />
+        <source-file src="src/android/Sms.java" target-dir="src/com/cordova/plugins/sms" />
     </platform>
 
     <platform name="wp8">


### PR DESCRIPTION
[This commit](https://github.com/cordova-sms/cordova-sms-plugin/commit/c72d7f0499131b0130d26f0e70e62f6f1413e437) changed the namespace of the plugin for Android, but the files were copied to the wrong folder according to plugin.xml. I adjusted the file in order for the namespace to match the folder structure.
