### PR TITLE
Execute success when the SMS composer is shown

### DIFF
--- a/src/windows/SmsProxy.js
+++ b/src/windows/SmsProxy.js
@@ -5,7 +5,7 @@ module.exports = {
         var chatMessage = new Windows.ApplicationModel.Chat.ChatMessage();
         chatMessage.body = args[1];
         chatMessage.recipients.push(args[0]);
-        Windows.ApplicationModel.Chat.ChatMessageManager.showComposeSmsMessageAsync(chatMessage);
+        Windows.ApplicationModel.Chat.ChatMessageManager.showComposeSmsMessageAsync(chatMessage).done(win, fail);
 
     }
 };


### PR DESCRIPTION
This isn't the best scenario since you don't know when the message is actually sent but I think this puts the API into closer parity with the other platforms.
