### PR TITLE
fix(android): Don't check permissions for intents

### DIFF
--- a/src/android/Sms.java
+++ b/src/android/Sms.java
@@ -38,7 +38,13 @@ public class Sms extends CordovaPlugin {
 		this.callbackContext = callbackContext;
 		this.args = args;
 		if (action.equals(ACTION_SEND_SMS)) {
-			if (hasPermission()) {
+			boolean isIntent = false;
+			try {
+				isIntent = args.getString(2).equalsIgnoreCase("INTENT");
+			} catch (NullPointerException npe) {
+				// It might throw a NPE, but it doesn't matter.
+			}
+			if (isIntent || hasPermission()) {
 				sendSMS();
 			} else {
 				requestPermission();


### PR DESCRIPTION
Fixes a bug on android where the app will ask for permission to send using an intent, which does not need any permissions.