### PR TITLE
Bugfix - Return error if SMS text is unavailable

### DIFF
--- a/src/ios/Sms.m
+++ b/src/ios/Sms.m
@@ -8,8 +8,9 @@
         self.callbackID = command.callbackId;
         
         if(![MFMessageComposeViewController canSendText]) {
+            NSString *errorMessage = @"SMS Text not available.";
             UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notice"
-                                                            message:@"SMS Text not available."
+                                                            message:errorMessage
                                                            delegate:self
                                                   cancelButtonTitle:@"OK"
                                                   otherButtonTitles:nil
@@ -17,6 +18,10 @@
 
             dispatch_async(dispatch_get_main_queue(), ^{
                 [alert show];
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                                  messageAsString:errorMessage];
+
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackID];
             });
             return;
         }


### PR DESCRIPTION
- Return an error state back to cordova if SMS texting is unavailable for iOS.
- Previously was not returning anything so the promise could never be resolved on the Javascript side.