### PR TITLE
Expose requestPermission to JavaScript

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ Javascript
         }
     };
 
-On Android, an extra function is exposed to know whether or not you have the permission to send a SMS (Android Marshmallow permission).
+On Android, two extra functions are exposed to know whether or not an app has permission and to request permission to send SMS (Android Marshmallow +).
 
     var app = {
         checkSMSPermission: function() {
@@ -53,6 +53,15 @@ On Android, an extra function is exposed to know whether or not you have the per
                 else {
                     // show a helpful message to explain why you need to require the permission to send a SMS
                     // read http://developer.android.com/training/permissions/requesting.html#explain for more best practices
+                }
+            };
+            var error = function (e) { alert('Something went wrong:' + e); };
+            sms.hasPermission(success, error);
+        },
+        requestSMSPermission: function() {
+            var success = function (hasPermission) { 
+                if (!hasPermission) {
+                    sms.requestPermission();
                 }
             };
             var error = function (e) { alert('Something went wrong:' + e); };

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,12 @@ On Android, two extra functions are exposed to know whether or not an app has pe
         requestSMSPermission: function() {
             var success = function (hasPermission) { 
                 if (!hasPermission) {
-                    sms.requestPermission();
+                    sms.requestPermission(function() {
+                        console.log('[OK] Permission accepted')
+                    }, function(error) {
+                        console.info('[WARN] Permission not accepted')
+                        // Handle permission not accepted
+                    })
                 }
             };
             var error = function (e) { alert('Something went wrong:' + e); };

--- a/src/android/Sms.java
+++ b/src/android/Sms.java
@@ -31,6 +31,8 @@ public class Sms extends CordovaPlugin {
 
 	private static final int SEND_SMS_REQ_CODE = 0;
 
+	private static final int REQUEST_PERMISSION_REQ_CODE = 1;
+
 	private CallbackContext callbackContext;
 
 	private JSONArray args;
@@ -49,7 +51,7 @@ public class Sms extends CordovaPlugin {
 			if (isIntent || hasPermission()) {
 				sendSMS();
 			} else {
-				requestPermission();
+				requestPermission(SEND_SMS_REQ_CODE);
 			}
 			return true;
 		}
@@ -58,8 +60,7 @@ public class Sms extends CordovaPlugin {
 			return true;
 		}
 		else if (action.equals(ACTION_REQUEST_PERMISSION)) {
-			requestPermission();
-			callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
+			requestPermission(REQUEST_PERMISSION_REQ_CODE);
 			return true;
 		}
 		return false;
@@ -69,8 +70,8 @@ public class Sms extends CordovaPlugin {
 		return cordova.hasPermission(android.Manifest.permission.SEND_SMS);
 	}
 
-	private void requestPermission() {
-		cordova.requestPermission(this, SEND_SMS_REQ_CODE, android.Manifest.permission.SEND_SMS);
+	private void requestPermission(int requestCode) {
+		cordova.requestPermission(this, requestCode, android.Manifest.permission.SEND_SMS);
 	}
 
 	public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
@@ -80,7 +81,11 @@ public class Sms extends CordovaPlugin {
 				return;
 			}
 		}
-		sendSMS();
+		if (requestCode == SEND_SMS_REQ_CODE) {
+			sendSMS();
+			return;
+		}
+		callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
 	}
 
 	private boolean sendSMS() {

--- a/src/android/Sms.java
+++ b/src/android/Sms.java
@@ -24,6 +24,8 @@ public class Sms extends CordovaPlugin {
 	public final String ACTION_SEND_SMS = "send";
 
 	public final String ACTION_HAS_PERMISSION = "has_permission";
+	
+	public final String ACTION_REQUEST_PERMISSION = "request_permission";
 
 	private static final String INTENT_FILTER_SMS_SENT = "SMS_SENT";
 
@@ -53,6 +55,11 @@ public class Sms extends CordovaPlugin {
 		}
 		else if (action.equals(ACTION_HAS_PERMISSION)) {
 			callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, hasPermission()));
+			return true;
+		}
+		else if (action.equals(ACTION_REQUEST_PERMISSION)) {
+			requestPermission();
+			callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
 			return true;
 		}
 		return false;

--- a/www/sms.js
+++ b/www/sms.js
@@ -52,4 +52,14 @@ sms.hasPermission = function(success, failure) {
     );
 };
 
+sms.requestPermission = function(success, failure) {
+    // fire
+    exec(
+        success,
+        failure,
+        'Sms',
+        'request_permission', []
+    );
+};
+
 module.exports = sms;


### PR DESCRIPTION
On Android 6+, improve user experience by allowing control over when SMS privilege is requested, not just when the first message is sent.

As an example an enable sms button can request permission right away:

```javascript
sms.hasPermission(function(hasPermission) {
  if (!hasPermission) {
    sms.requestPermission()
  }
});
```