### PR TITLE
Fixed issue with no recipients for Windows platform

### DIFF
--- a/src/windows/SmsProxy.js
+++ b/src/windows/SmsProxy.js
@@ -4,7 +4,7 @@ module.exports = {
 
         var chatMessage = new Windows.ApplicationModel.Chat.ChatMessage();
         chatMessage.body = args[1];
-        const validRecipent = args[0].every(function (r) {
+        const validRecipent = args[0] && args[0].every(function (r) {
             return !r == false;
         });
         if (validRecipent) {

--- a/src/windows/SmsProxy.js
+++ b/src/windows/SmsProxy.js
@@ -4,7 +4,10 @@ module.exports = {
 
         var chatMessage = new Windows.ApplicationModel.Chat.ChatMessage();
         chatMessage.body = args[1];
-        if (args[0]) {
+        const validRecipent = args[0].every(function (r) {
+            return !r == false;
+        });
+        if (validRecipent) {
             chatMessage.recipients.push(args[0]);
         }
         Windows.ApplicationModel.Chat.ChatMessageManager.showComposeSmsMessageAsync(chatMessage).done(win, fail);

--- a/src/windows/SmsProxy.js
+++ b/src/windows/SmsProxy.js
@@ -4,7 +4,9 @@ module.exports = {
 
         var chatMessage = new Windows.ApplicationModel.Chat.ChatMessage();
         chatMessage.body = args[1];
-        chatMessage.recipients.push(args[0]);
+        if (args[0]) {
+            chatMessage.recipients.push(args[0]);
+        }
         Windows.ApplicationModel.Chat.ChatMessageManager.showComposeSmsMessageAsync(chatMessage).done(win, fail);
 
     }


### PR DESCRIPTION
When blank string/undefined/null is specified for recipient parameter, it throws invalid argument exception. This PR fixes that.