### PR TITLE
Image attachments support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,12 +23,27 @@
                 <param name="android-package" value="com.cordova.plugins.sms.Sms"/>
             </feature>
         </config-file>
+        
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-feature android:name="android.hardware.telephony" android:required="false" />
         </config-file>
+        <config-file target="AndroidManifest.xml" parent="application">
+            <provider
+                android:name="androidx.core.content.FileProvider"
+                android:authorities="${applicationId}.cordova.plugins.sms.fileprovider"
+                android:grantUriPermissions="true"
+                android:exported="false">
+                <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/cordova_sms_filepaths" />
+            </provider>
+        </config-file>
 
         <source-file src="src/android/Sms.java" target-dir="src/com/cordova/plugins/sms" />
+        <source-file
+            src="src/android/xml/cordova_sms_filepaths.xml"
+            target-dir="res/xml" />
     </platform>
 
     <!-- wp8 -->

--- a/src/android/xml/cordova_sms_filepaths.xml
+++ b/src/android/xml/cordova_sms_filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache_files" path="." />
+</paths>

--- a/src/ios/Sms.m
+++ b/src/ios/Sms.m
@@ -47,6 +47,21 @@
 
                 [composeViewController setRecipients:recipients];
             }
+            
+            NSMutableDictionary* attachments = [command.arguments objectAtIndex:4];
+            if (attachments != nil && ![attachments isEqual:[NSNull null]]) {
+                for (NSString* filename in attachments) {
+                    NSString* imgStr = [attachments objectForKey:filename]; 
+                    NSData *data  = [[NSData alloc] initWithBase64EncodedString:imgStr options:0];
+                    UIImage *image = [UIImage imageWithData:data];
+                    if (image != nil) {
+                        NSData* attachment = UIImageJPEGRepresentation(image, 1.0);
+                        [composeViewController 
+                            addAttachmentData:attachment 
+                            typeIdentifier:@"public.jpeg" filename:filename];
+                    }
+                }
+            }
             [self.viewController presentViewController:composeViewController animated:YES completion:nil];
         });
     }];

--- a/www/sms.js
+++ b/www/sms.js
@@ -22,6 +22,7 @@ sms.send = function(phone, message, options, success, failure) {
     // parsing options
     var replaceLineBreaks = false;
     var androidIntent = '';
+    var attachments = null;
     if (typeof options === 'string') { // ensuring backward compatibility
         window.console.warn('[DEPRECATED] Passing a string as a third argument is deprecated. Please refer to the documentation to pass the right parameter: https://github.com/cordova-sms/cordova-sms-plugin.');
         androidIntent = options;
@@ -31,6 +32,13 @@ sms.send = function(phone, message, options, success, failure) {
         if (options.android && typeof options.android === 'object') {
             androidIntent = options.android.intent;
         }
+        if (options.attachments) {
+            if (Array.isArray(options.attachments)) {
+                attachments = options.attachments;
+            } else {
+                attachments = [options.attachments]
+            }
+        }
     }
 
     // fire
@@ -38,7 +46,7 @@ sms.send = function(phone, message, options, success, failure) {
         success,
         failure,
         'Sms',
-        'send', [phone, message, androidIntent, replaceLineBreaks]
+        'send', [phone, message, androidIntent, replaceLineBreaks, attachments]
     );
 };
 

--- a/www/sms.js
+++ b/www/sms.js
@@ -33,11 +33,7 @@ sms.send = function(phone, message, options, success, failure) {
             androidIntent = options.android.intent;
         }
         if (options.attachments) {
-            if (Array.isArray(options.attachments)) {
-                attachments = options.attachments;
-            } else {
-                attachments = [options.attachments]
-            }
+            attachments = options.attachments;
         }
     }
 


### PR DESCRIPTION
## Purpose
This pull request enhance the plugin with partial support for image attachment.
To add image to sent sms the `attachments` property of the `options` should contains an object which has for key the filename of the attached images and for value a base64 string representation of the image, example: 

```javascript
const options = {
  attachments: {
   'image1.jpg' : "....base64string...", 
   'image2.jpg' : "....base64string...", 
  }
}
sms.send(number, message, options, success, error);

```
## IOS Support

The new feature works fine on IOS (at least based on my tests).

## Android Support

The plugin only support the `INTENT` method for image attachement.
Also providing a non empty phone number and attaching multiple image does not work. 
I can't understand why but `Intent.ACTION_SEND` supports providing sms number while `Intent.ACTION_SEND_MULTIPLE`  does not (`Intent.ACTION_SEND_TO` does not support attachment ...).

## Windows
Not implemented
