### PR TITLE
Updated PendingIntent creation for apps targeting android 12+

### DIFF
--- a/src/android/Sms.java
+++ b/src/android/Sms.java
@@ -196,7 +196,7 @@ public class Sms extends CordovaPlugin {
 		String intentFilterAction = INTENT_FILTER_SMS_SENT + java.util.UUID.randomUUID().toString();
 		this.cordova.getActivity().registerReceiver(broadcastReceiver, new IntentFilter(intentFilterAction));
 
-		PendingIntent sentIntent = PendingIntent.getBroadcast(this.cordova.getActivity(), 0, new Intent(intentFilterAction), 0);
+		PendingIntent sentIntent = PendingIntent.getBroadcast(this.cordova.getActivity(), 0, new Intent(intentFilterAction), PendingIntent.FLAG_IMMUTABLE);
 
 		// depending on the number of parts we send a text message or multi parts
 		if (parts.size() > 1) {


### PR DESCRIPTION
Applications targeting Android 12+ crash on PendingIntent creation, on Android 12+.
Pending intents must specify either FLAG_IMMUTABLE or FLAG_MUTABLE:

> Up until Build.VERSION_CODES.R, PendingIntents are assumed to be mutable by default, unless FLAG_IMMUTABLE is set. Starting with Build.VERSION_CODES.S, it will be required to explicitly specify the mutability of PendingIntents on creation with either (https://github.com/link #FLAG_IMMUTABLE} or FLAG_MUTABLE. It is strongly recommended to use FLAG_IMMUTABLE when creating a PendingIntent. FLAG_MUTABLE should only be used when some functionality relies on modifying the underlying intent, e.g. any PendingIntent that needs to be used with inline reply or bubbles.

The flag FLAG_IMMUTABLE has been added to the getBroadcast function call.